### PR TITLE
Fixing driver NPEs in tear down methods for JUnit

### DIFF
--- a/junit/src/test/java/com/saucelabs/junit/SampleSauceTest.java
+++ b/junit/src/test/java/com/saucelabs/junit/SampleSauceTest.java
@@ -93,7 +93,9 @@ public class SampleSauceTest implements SauceOnDemandSessionIdProvider {
 
     @After
     public void tearDown() {
-        driver.quit();
+        if(driver != null) {
+            driver.quit();
+        }
     }
 
     @Override

--- a/junit/src/test/java/com/saucelabs/junit/WebDriverDemoShootoutTest.java
+++ b/junit/src/test/java/com/saucelabs/junit/WebDriverDemoShootoutTest.java
@@ -45,7 +45,9 @@ public class WebDriverDemoShootoutTest implements SauceOnDemandSessionIdProvider
 
     @After
     public void tearDown() {
-        driver.quit();
+        if(driver != null) {
+            driver.quit();
+        }
     }
 
     @Test

--- a/junit/src/test/java/com/saucelabs/junit/WebDriverParallelWithHelper.java
+++ b/junit/src/test/java/com/saucelabs/junit/WebDriverParallelWithHelper.java
@@ -81,6 +81,8 @@ public class WebDriverParallelWithHelper implements SauceOnDemandSessionIdProvid
 
     @After
     public void tearDown() {
-        driver.quit();
+        if(driver != null) {
+            driver.quit();
+        }
     }
 }

--- a/junit/src/test/java/com/saucelabs/junit/WebDriverTest.java
+++ b/junit/src/test/java/com/saucelabs/junit/WebDriverTest.java
@@ -54,10 +54,16 @@ public class WebDriverTest implements SauceOnDemandSessionIdProvider {
         assertEquals("I am a page title - Sauce Labs", driver.getTitle());
     }
 
+    @Test
+    public void assertDriverNotNull(){
+        assertNotNull(driver);
+    }
+
     @After
     public void tearDown() {
-        assertNotNull(driver);
-        driver.quit();
+        if(driver != null) {
+            driver.quit();
+        }
     }
 
     @Override


### PR DESCRIPTION
At this moment, every time a JUnit test fails and the driver is left as
null, an extra NPE will be thrown each time driver.quit() is called. This
commit fixes this issue by asking every time if driver is different from
null before quitting the driver.
Also, there is a solution for issue #56.